### PR TITLE
Blood Glucose Delta Display

### DIFF
--- a/app/src/main/java/im/rah/nightwear/BloodGlucose.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucose.kt
@@ -57,15 +57,6 @@ class BloodGlucose(val glucoseLevel_mgdl: Int, val sensorTime: Long, val directi
         @JvmStatic fun parseTabSeparatedRecent(str: String): List<BloodGlucose?> {
             return str.lines().map { parseTabSeparatedCurrent(it) }
         }
-
-        fun glucose(mgdl: Int, mmol: Boolean = true): String {
-            return if (mmol) {
-                DecimalFormat("##.0").format(mgdl / MMOLL_TO_MGDL)
-            }
-            else {
-                mgdl.toString()
-            }
-        }
     }
 
     override fun toString() = BloodGlucosePresenter(this).combinedString()

--- a/app/src/main/java/im/rah/nightwear/BloodGlucose.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucose.kt
@@ -54,6 +54,10 @@ class BloodGlucose(val glucoseLevel_mgdl: Int, val sensorTime: Long, val directi
             }
         }
 
+        @JvmStatic fun parseTabSeparatedRecent(str: String): List<BloodGlucose?> {
+            return str.lines().map { parseTabSeparatedCurrent(it) }
+        }
+
         fun glucose(mgdl: Int, mmol: Boolean = true): String {
             return if (mmol) {
                 DecimalFormat("##.0").format(mgdl / MMOLL_TO_MGDL)

--- a/app/src/main/java/im/rah/nightwear/BloodGlucose.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucose.kt
@@ -68,18 +68,7 @@ class BloodGlucose(val glucoseLevel_mgdl: Int, val sensorTime: Long, val directi
         }
     }
 
-    fun glucose(mmol: Boolean = true) = glucose(glucoseLevel_mgdl, mmol)
-    fun directionLabel(saferUnicode: Boolean = false) =
-        if (saferUnicode) direction.saferLabel else direction.bolderLabel
-    fun annotation(markOld: Boolean, saferUnicode: Boolean = false) : String {
-        return when {
-            markOld && readingAge() > OLD_READING_THRESHOLD -> "OLD"
-            else -> directionLabel(saferUnicode)
-        }
-    }
-    fun combinedString(mmol: Boolean = true, markOld: Boolean = false, saferUnicode: Boolean = false) =
-        glucose(mmol) + " " + annotation(markOld, saferUnicode)
-    override fun toString() = combinedString()
+    override fun toString() = BloodGlucosePresenter(this).combinedString()
 
     fun sensorTimeInstant() = Instant.ofEpochMilli(sensorTime)
     fun readingAge() = Duration.between(sensorTimeInstant(), Instant.now())

--- a/app/src/main/java/im/rah/nightwear/BloodGlucoseDelta.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucoseDelta.kt
@@ -1,14 +1,16 @@
 package im.rah.nightwear
 
-// The modelling here is clean and intuitive, but using mg/dL differences will lead to rounding
-// inconsistencies for mmol/L with both the NightScout displayed deltas, but also with what we
-// we expect from the change observed.
-//
-// To overcome this we'll need to convert units before calculating the difference.
-class BloodGlucoseDelta(val delta_mgdl: Int) {
-    companion object {
-        fun between(first: BloodGlucose, second: BloodGlucose): BloodGlucoseDelta {
-            return BloodGlucoseDelta(second.glucoseLevel_mgdl - first.glucoseLevel_mgdl)
-        }
+import java.text.DecimalFormat
+
+// Initially this was modelled, storing a single mg/dL difference, but this leads to rounding
+// inconsistencies when displaying in mmol/L - instead we have to calculate the difference in the
+// display units.
+class BloodGlucoseDelta(val first: BloodGlucose, val second: BloodGlucose) {
+    fun in_mgdl() = second.glucoseLevel_mgdl - first.glucoseLevel_mgdl
+    fun in_mmol() = rounded_mmol(second) - rounded_mmol(first)
+
+    private fun rounded_mmol(bg: BloodGlucose): Double {
+        val mmol : Double = bg.glucoseLevel_mgdl / BloodGlucose.MMOLL_TO_MGDL
+        return DecimalFormat("#.#").format(mmol).toDouble()
     }
 }

--- a/app/src/main/java/im/rah/nightwear/BloodGlucoseDelta.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucoseDelta.kt
@@ -1,5 +1,10 @@
 package im.rah.nightwear
 
+// The modelling here is clean and intuitive, but using mg/dL differences will lead to rounding
+// inconsistencies for mmol/L with both the NightScout displayed deltas, but also with what we
+// we expect from the change observed.
+//
+// To overcome this we'll need to convert units before calculating the difference.
 class BloodGlucoseDelta(val delta_mgdl: Int) {
     companion object {
         fun between(first: BloodGlucose, second: BloodGlucose): BloodGlucoseDelta {

--- a/app/src/main/java/im/rah/nightwear/BloodGlucoseDelta.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucoseDelta.kt
@@ -6,10 +6,10 @@ import java.text.DecimalFormat
 // inconsistencies when displaying in mmol/L - instead we have to calculate the difference in the
 // display units.
 class BloodGlucoseDelta(val first: BloodGlucose, val second: BloodGlucose) {
-    fun in_mgdl() = second.glucoseLevel_mgdl - first.glucoseLevel_mgdl
-    fun in_mmol() = rounded_mmol(second) - rounded_mmol(first)
+    fun inMgdl() = second.glucoseLevel_mgdl - first.glucoseLevel_mgdl
+    fun inMmol() = roundedMmol(second) - roundedMmol(first)
 
-    private fun rounded_mmol(bg: BloodGlucose): Double {
+    private fun roundedMmol(bg: BloodGlucose): Double {
         val mmol : Double = bg.glucoseLevel_mgdl / BloodGlucose.MMOLL_TO_MGDL
         return DecimalFormat("#.#").format(mmol).toDouble()
     }

--- a/app/src/main/java/im/rah/nightwear/BloodGlucoseDelta.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucoseDelta.kt
@@ -1,0 +1,9 @@
+package im.rah.nightwear
+
+class BloodGlucoseDelta(val delta_mgdl: Int) {
+    companion object {
+        fun between(first: BloodGlucose, second: BloodGlucose): BloodGlucoseDelta {
+            return BloodGlucoseDelta(second.glucoseLevel_mgdl - first.glucoseLevel_mgdl)
+        }
+    }
+}

--- a/app/src/main/java/im/rah/nightwear/BloodGlucoseDeltaPresenter.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucoseDeltaPresenter.kt
@@ -6,10 +6,17 @@ class BloodGlucoseDeltaPresenter(private val bgDelta: BloodGlucoseDelta,
                                  private val mmol: Boolean = true) {
     override fun toString(): String {
         return if (mmol) {
-            DecimalFormat("##.0").format(bgDelta.delta_mgdl / BloodGlucose.MMOLL_TO_MGDL)
+            prefix() + DecimalFormat("0.0").format(bgDelta.delta_mgdl / BloodGlucose.MMOLL_TO_MGDL)
         }
         else {
-            bgDelta.delta_mgdl.toString()
+            prefix() + bgDelta.delta_mgdl.toString()
+        }
+    }
+
+    private fun prefix(): String {
+        return when {
+            bgDelta.delta_mgdl > 0 -> { "+" }
+            else -> { "" }
         }
     }
 }

--- a/app/src/main/java/im/rah/nightwear/BloodGlucoseDeltaPresenter.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucoseDeltaPresenter.kt
@@ -7,16 +7,16 @@ class BloodGlucoseDeltaPresenter(private val bgDelta: BloodGlucoseDelta,
                                  private val showUnits: Boolean = true) {
     override fun toString(): String {
         return if (mmol) {
-            prefix() + DecimalFormat("0.0").format(bgDelta.in_mmol()) + postfix()
+            prefix() + DecimalFormat("0.0").format(bgDelta.inMmol()) + postfix()
         }
         else {
-            prefix() + bgDelta.in_mgdl().toString() + postfix()
+            prefix() + bgDelta.inMgdl().toString() + postfix()
         }
     }
 
     private fun prefix(): String {
         return when {
-            (mmol && bgDelta.in_mmol() > 0) || (!mmol && bgDelta.in_mgdl() > 0) -> { "+" }
+            (mmol && bgDelta.inMmol() > 0) || (!mmol && bgDelta.inMgdl() > 0) -> { "+" }
             else -> { "" }
         }
     }

--- a/app/src/main/java/im/rah/nightwear/BloodGlucoseDeltaPresenter.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucoseDeltaPresenter.kt
@@ -16,7 +16,7 @@ class BloodGlucoseDeltaPresenter(private val bgDelta: BloodGlucoseDelta,
 
     private fun prefix(): String {
         return when {
-            (mmol && bgDelta.inMmol() > 0) || (!mmol && bgDelta.inMgdl() > 0) -> { "+" }
+            (mmol && bgDelta.inMmol() >= 0) || (!mmol && bgDelta.inMgdl() >= 0) -> { "+" }
             else -> { "" }
         }
     }

--- a/app/src/main/java/im/rah/nightwear/BloodGlucoseDeltaPresenter.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucoseDeltaPresenter.kt
@@ -7,16 +7,16 @@ class BloodGlucoseDeltaPresenter(private val bgDelta: BloodGlucoseDelta,
                                  private val showUnits: Boolean = true) {
     override fun toString(): String {
         return if (mmol) {
-            prefix() + DecimalFormat("0.0").format(bgDelta.delta_mgdl / BloodGlucose.MMOLL_TO_MGDL) + postfix()
+            prefix() + DecimalFormat("0.0").format(bgDelta.in_mmol()) + postfix()
         }
         else {
-            prefix() + bgDelta.delta_mgdl.toString() + postfix()
+            prefix() + bgDelta.in_mgdl().toString() + postfix()
         }
     }
 
     private fun prefix(): String {
         return when {
-            bgDelta.delta_mgdl > 0 -> { "+" }
+            (mmol && bgDelta.in_mmol() > 0) || (!mmol && bgDelta.in_mgdl() > 0) -> { "+" }
             else -> { "" }
         }
     }

--- a/app/src/main/java/im/rah/nightwear/BloodGlucoseDeltaPresenter.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucoseDeltaPresenter.kt
@@ -1,0 +1,15 @@
+package im.rah.nightwear
+
+import java.text.DecimalFormat
+
+class BloodGlucoseDeltaPresenter(private val bgDelta: BloodGlucoseDelta,
+                                 private val mmol: Boolean = true) {
+    override fun toString(): String {
+        return if (mmol) {
+            DecimalFormat("##.0").format(bgDelta.delta_mgdl / BloodGlucose.MMOLL_TO_MGDL)
+        }
+        else {
+            bgDelta.delta_mgdl.toString()
+        }
+    }
+}

--- a/app/src/main/java/im/rah/nightwear/BloodGlucoseDeltaPresenter.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucoseDeltaPresenter.kt
@@ -3,13 +3,14 @@ package im.rah.nightwear
 import java.text.DecimalFormat
 
 class BloodGlucoseDeltaPresenter(private val bgDelta: BloodGlucoseDelta,
-                                 private val mmol: Boolean = true) {
+                                 private val mmol: Boolean = true,
+                                 private val showUnits: Boolean = true) {
     override fun toString(): String {
         return if (mmol) {
-            prefix() + DecimalFormat("0.0").format(bgDelta.delta_mgdl / BloodGlucose.MMOLL_TO_MGDL)
+            prefix() + DecimalFormat("0.0").format(bgDelta.delta_mgdl / BloodGlucose.MMOLL_TO_MGDL) + postfix()
         }
         else {
-            prefix() + bgDelta.delta_mgdl.toString()
+            prefix() + bgDelta.delta_mgdl.toString() + postfix()
         }
     }
 
@@ -18,5 +19,12 @@ class BloodGlucoseDeltaPresenter(private val bgDelta: BloodGlucoseDelta,
             bgDelta.delta_mgdl > 0 -> { "+" }
             else -> { "" }
         }
+    }
+
+    private fun postfix(): String {
+        if (!showUnits) return ""
+
+        return if (mmol) " " + BloodGlucose.Unit.MMOL.label
+        else " " + BloodGlucose.Unit.MGDL.label
     }
 }

--- a/app/src/main/java/im/rah/nightwear/BloodGlucosePresenter.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucosePresenter.kt
@@ -1,15 +1,17 @@
 package im.rah.nightwear
 
-class BloodGlucosePresenter(private val bg: BloodGlucose, private val mmol: Boolean = true) {
+class BloodGlucosePresenter(private val bg: BloodGlucose,
+                            private val mmol: Boolean = true,
+                            private val markOld: Boolean = false,
+                            private val saferUnicode: Boolean = false) {
     private fun glucose() = BloodGlucose.glucose(bg.glucoseLevel_mgdl, mmol)
-    private fun directionLabel(saferUnicode: Boolean = false) =
+    private fun directionLabel() =
         if (saferUnicode) bg.direction.saferLabel else bg.direction.bolderLabel
-    private fun annotation(markOld: Boolean, saferUnicode: Boolean = false) : String {
+    private fun annotation() : String {
         return when {
             markOld && bg.readingAge() > BloodGlucose.OLD_READING_THRESHOLD -> "OLD"
-            else -> directionLabel(saferUnicode)
+            else -> directionLabel()
         }
     }
-    fun combinedString(markOld: Boolean = false, saferUnicode: Boolean = false) =
-        glucose() + " " + annotation(markOld, saferUnicode)
+    fun combinedString() = glucose() + " " + annotation()
 }

--- a/app/src/main/java/im/rah/nightwear/BloodGlucosePresenter.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucosePresenter.kt
@@ -1,7 +1,7 @@
 package im.rah.nightwear
 
-class BloodGlucosePresenter(private val bg: BloodGlucose) {
-    fun glucose(mmol: Boolean = true) = BloodGlucose.glucose(bg.glucoseLevel_mgdl, mmol)
+class BloodGlucosePresenter(private val bg: BloodGlucose, private val mmol: Boolean = true) {
+    fun glucose() = BloodGlucose.glucose(bg.glucoseLevel_mgdl, mmol)
     fun directionLabel(saferUnicode: Boolean = false) =
         if (saferUnicode) bg.direction.saferLabel else bg.direction.bolderLabel
     fun annotation(markOld: Boolean, saferUnicode: Boolean = false) : String {
@@ -10,6 +10,6 @@ class BloodGlucosePresenter(private val bg: BloodGlucose) {
             else -> directionLabel(saferUnicode)
         }
     }
-    fun combinedString(mmol: Boolean = true, markOld: Boolean = false, saferUnicode: Boolean = false) =
-        glucose(mmol) + " " + annotation(markOld, saferUnicode)
+    fun combinedString(markOld: Boolean = false, saferUnicode: Boolean = false) =
+        glucose() + " " + annotation(markOld, saferUnicode)
 }

--- a/app/src/main/java/im/rah/nightwear/BloodGlucosePresenter.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucosePresenter.kt
@@ -1,0 +1,15 @@
+package im.rah.nightwear
+
+class BloodGlucosePresenter(private val bg: BloodGlucose) {
+    fun glucose(mmol: Boolean = true) = BloodGlucose.glucose(bg.glucoseLevel_mgdl, mmol)
+    fun directionLabel(saferUnicode: Boolean = false) =
+        if (saferUnicode) bg.direction.saferLabel else bg.direction.bolderLabel
+    fun annotation(markOld: Boolean, saferUnicode: Boolean = false) : String {
+        return when {
+            markOld && bg.readingAge() > BloodGlucose.OLD_READING_THRESHOLD -> "OLD"
+            else -> directionLabel(saferUnicode)
+        }
+    }
+    fun combinedString(mmol: Boolean = true, markOld: Boolean = false, saferUnicode: Boolean = false) =
+        glucose(mmol) + " " + annotation(markOld, saferUnicode)
+}

--- a/app/src/main/java/im/rah/nightwear/BloodGlucosePresenter.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucosePresenter.kt
@@ -1,10 +1,10 @@
 package im.rah.nightwear
 
 class BloodGlucosePresenter(private val bg: BloodGlucose, private val mmol: Boolean = true) {
-    fun glucose() = BloodGlucose.glucose(bg.glucoseLevel_mgdl, mmol)
-    fun directionLabel(saferUnicode: Boolean = false) =
+    private fun glucose() = BloodGlucose.glucose(bg.glucoseLevel_mgdl, mmol)
+    private fun directionLabel(saferUnicode: Boolean = false) =
         if (saferUnicode) bg.direction.saferLabel else bg.direction.bolderLabel
-    fun annotation(markOld: Boolean, saferUnicode: Boolean = false) : String {
+    private fun annotation(markOld: Boolean, saferUnicode: Boolean = false) : String {
         return when {
             markOld && bg.readingAge() > BloodGlucose.OLD_READING_THRESHOLD -> "OLD"
             else -> directionLabel(saferUnicode)

--- a/app/src/main/java/im/rah/nightwear/BloodGlucosePresenter.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucosePresenter.kt
@@ -1,13 +1,22 @@
 package im.rah.nightwear
 
+import java.text.DecimalFormat
+
 class BloodGlucosePresenter(private val bg: BloodGlucose,
                             private val mmol: Boolean = true,
                             private val markOld: Boolean = false,
                             private val saferUnicode: Boolean = false) {
-    private fun glucose() = BloodGlucose.glucose(bg.glucoseLevel_mgdl, mmol)
+    private fun glucose(): String {
+        return if (mmol) {
+            DecimalFormat("##.0").format(bg.glucoseLevel_mgdl / BloodGlucose.MMOLL_TO_MGDL)
+        }
+        else {
+            bg.glucoseLevel_mgdl.toString()
+        }
+    }
     private fun directionLabel() =
         if (saferUnicode) bg.direction.saferLabel else bg.direction.bolderLabel
-    private fun annotation() : String {
+    private fun annotation(): String {
         return when {
             markOld && bg.readingAge() > BloodGlucose.OLD_READING_THRESHOLD -> "OLD"
             else -> directionLabel()

--- a/app/src/main/java/im/rah/nightwear/BloodGlucoseService.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucoseService.kt
@@ -26,7 +26,7 @@ class BloodGlucoseService(context: Context) : SharedPreferences.OnSharedPreferen
         if (latestBg == null) return null
         if (penultimateBg == null) return null
 
-        return BloodGlucoseDelta.between(penultimateBg!!, latestBg!!)
+        return BloodGlucoseDelta(penultimateBg!!, latestBg!!)
     }
     var onDataUpdateListeners: MutableList<(BloodGlucose)->Unit> = mutableListOf()
 

--- a/app/src/main/java/im/rah/nightwear/BloodGlucoseService.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucoseService.kt
@@ -39,7 +39,6 @@ class BloodGlucoseService(context: Context) : SharedPreferences.OnSharedPreferen
         const val TAG:String = "BloodGlucoseService"
         val SENSOR_REFRESH_INTERVAL:Duration = Duration.ofMinutes(5)
 
-        const val NS_CURRENT_ENTRY_PATH = "/api/v1/entries/current"
         const val NS_RECENT_ENTRIES_PATH = "/api/v1/entries/sgv"
 
         private var instance:BloodGlucoseService? = null

--- a/app/src/main/java/im/rah/nightwear/BloodGlucoseService.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucoseService.kt
@@ -18,7 +18,16 @@ import kotlin.concurrent.schedule
 import android.content.ComponentName
 
 class BloodGlucoseService(context: Context) : SharedPreferences.OnSharedPreferenceChangeListener {
-    var latestBg:BloodGlucose? = null
+    var recentEntries:List<BloodGlucose?> = List<BloodGlucose?>(0) { null }
+    val latestBg get() = recentEntries.firstOrNull()
+    val penultimateBg get() = recentEntries.elementAtOrNull(1)
+    val latestDelta: BloodGlucoseDelta? get() {
+        if (recentEntries.size < 2) return null
+        if (latestBg == null) return null
+        if (penultimateBg == null) return null
+
+        return BloodGlucoseDelta.between(penultimateBg!!, latestBg!!)
+    }
     var onDataUpdateListeners: MutableList<(BloodGlucose)->Unit> = mutableListOf()
 
     private var nightscoutBaseUrl = ""
@@ -31,6 +40,7 @@ class BloodGlucoseService(context: Context) : SharedPreferences.OnSharedPreferen
         val SENSOR_REFRESH_INTERVAL:Duration = Duration.ofMinutes(5)
 
         const val NS_CURRENT_ENTRY_PATH = "/api/v1/entries/current"
+        const val NS_RECENT_ENTRIES_PATH = "/api/v1/entries/sgv"
 
         private var instance:BloodGlucoseService? = null
 
@@ -78,12 +88,12 @@ class BloodGlucoseService(context: Context) : SharedPreferences.OnSharedPreferen
     override fun onSharedPreferenceChanged(prefs: SharedPreferences, key: String) {
         Log.d(tag, "prefs changed")
         if (key == "nightscoutBaseUrl") {
-          nightscoutBaseUrl = prefs.getString("nightscoutBaseUrl", "")!!
+            nightscoutBaseUrl = prefs.getString("nightscoutBaseUrl", "")!!
         }
     }
 
-    private fun nsCurrentEntryUrl() : String {
-        return nightscoutBaseUrl + NS_CURRENT_ENTRY_PATH
+    private fun nsRecentEntriesUrl() : String {
+        return nightscoutBaseUrl + NS_RECENT_ENTRIES_PATH
     }
 
     fun refresh(force: Boolean = false) {
@@ -108,11 +118,11 @@ class BloodGlucoseService(context: Context) : SharedPreferences.OnSharedPreferen
 
         lastRequestAdded = Instant.now()
         val stringRequest = StringRequest(
-            Request.Method.GET, nsCurrentEntryUrl(),
+            Request.Method.GET, nsRecentEntriesUrl(),
             Response.Listener<String> { response ->
-                Log.d(tag, "bg received, parsing...")
+                Log.d(tag, "recent bgs received, parsing...")
                 try {
-                    latestBg = BloodGlucose.parseTabSeparatedCurrent(response)
+                    recentEntries = BloodGlucose.parseTabSeparatedRecent(response)
                     Log.d(tag, "  " + latestBg!! +  " notifying " + onDataUpdateListeners.size + " listeners")
                     onDataUpdateListeners.forEach {
                         it.invoke(latestBg!!)

--- a/app/src/main/java/im/rah/nightwear/BloodGlucoseService.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucoseService.kt
@@ -113,7 +113,7 @@ class BloodGlucoseService(context: Context) : SharedPreferences.OnSharedPreferen
                 Log.d(tag, "bg received, parsing...")
                 try {
                     latestBg = BloodGlucose.parseTabSeparatedCurrent(response)
-                    Log.d(tag, "  " + latestBg!!.combinedString() +  " notifying " + onDataUpdateListeners.size + " listeners")
+                    Log.d(tag, "  " + latestBg!! +  " notifying " + onDataUpdateListeners.size + " listeners")
                     onDataUpdateListeners.forEach {
                         it.invoke(latestBg!!)
                     }

--- a/app/src/main/java/im/rah/nightwear/BloodGlucoseService.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucoseService.kt
@@ -119,7 +119,7 @@ class BloodGlucoseService(context: Context) : SharedPreferences.OnSharedPreferen
         lastRequestAdded = Instant.now()
         val stringRequest = StringRequest(
             Request.Method.GET, nsRecentEntriesUrl(),
-            Response.Listener<String> { response ->
+            { response ->
                 Log.d(tag, "recent bgs received, parsing...")
                 try {
                     recentEntries = BloodGlucose.parseTabSeparatedRecent(response)
@@ -132,7 +132,7 @@ class BloodGlucoseService(context: Context) : SharedPreferences.OnSharedPreferen
                     Log.d(tag, "ParseException for response: " + response)
                 }
             },
-            Response.ErrorListener {
+            {
                 Log.d(tag, "request error")
             })
         stringRequest.tag = this

--- a/app/src/main/java/im/rah/nightwear/BloodGlucoseService.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucoseService.kt
@@ -124,6 +124,7 @@ class BloodGlucoseService(context: Context) : SharedPreferences.OnSharedPreferen
                 try {
                     recentEntries = BloodGlucose.parseTabSeparatedRecent(response)
                     Log.d(tag, "  " + latestBg!! +  " notifying " + onDataUpdateListeners.size + " listeners")
+                    Log.d(tag, "  𝚫 " + BloodGlucoseDeltaPresenter(latestDelta!!))
                     onDataUpdateListeners.forEach {
                         it.invoke(latestBg!!)
                     }

--- a/app/src/main/java/im/rah/nightwear/NightWearComplicationProviderService.kt
+++ b/app/src/main/java/im/rah/nightwear/NightWearComplicationProviderService.kt
@@ -39,7 +39,7 @@ class NightWearComplicationProviderService : ComplicationProviderService() {
         val builder = ComplicationData.Builder(type)
         
         if (type == ComplicationData.TYPE_SHORT_TEXT) {
-            val bgText: String = bg.combinedString(mmol = mmol, markOld = true, saferUnicode = true)
+            val bgText: String = BloodGlucosePresenter(bg).combinedString(mmol = mmol, markOld = true, saferUnicode = true)
 
             Log.d(TAG, "updating complication data (SHORT_TEXT), bgText: " + bgText)
 
@@ -58,7 +58,7 @@ class NightWearComplicationProviderService : ComplicationProviderService() {
         }
 
         if (type == ComplicationData.TYPE_LONG_TEXT) {
-            val bgText: String = bg.combinedString(mmol = mmol, markOld = false, saferUnicode = true) + " (^1)" // the ^1 is interpolated with the age
+            val bgText: String = BloodGlucosePresenter(bg).combinedString(mmol = mmol, markOld = false, saferUnicode = true) + " (^1)" // the ^1 is interpolated with the age
 
             Log.d(TAG, "updating complication data (LONG_TEXT), bgText: " + bgText)
 

--- a/app/src/main/java/im/rah/nightwear/NightWearComplicationProviderService.kt
+++ b/app/src/main/java/im/rah/nightwear/NightWearComplicationProviderService.kt
@@ -39,7 +39,7 @@ class NightWearComplicationProviderService : ComplicationProviderService() {
         val builder = ComplicationData.Builder(type)
         
         if (type == ComplicationData.TYPE_SHORT_TEXT) {
-            val bgText: String = BloodGlucosePresenter(bg).combinedString(mmol = mmol, markOld = true, saferUnicode = true)
+            val bgText: String = BloodGlucosePresenter(bg, mmol = mmol).combinedString(markOld = true, saferUnicode = true)
 
             Log.d(TAG, "updating complication data (SHORT_TEXT), bgText: " + bgText)
 
@@ -58,7 +58,7 @@ class NightWearComplicationProviderService : ComplicationProviderService() {
         }
 
         if (type == ComplicationData.TYPE_LONG_TEXT) {
-            val bgText: String = BloodGlucosePresenter(bg).combinedString(mmol = mmol, markOld = false, saferUnicode = true) + " (^1)" // the ^1 is interpolated with the age
+            val bgText: String = BloodGlucosePresenter(bg, mmol = mmol).combinedString(markOld = false, saferUnicode = true) + " (^1)" // the ^1 is interpolated with the age
 
             Log.d(TAG, "updating complication data (LONG_TEXT), bgText: " + bgText)
 

--- a/app/src/main/java/im/rah/nightwear/NightWearComplicationProviderService.kt
+++ b/app/src/main/java/im/rah/nightwear/NightWearComplicationProviderService.kt
@@ -36,8 +36,10 @@ class NightWearComplicationProviderService : ComplicationProviderService() {
             bg = bloodGlucoseService.latestBg!!
         }
 
+        val bgDelta = bloodGlucoseService.latestDelta
+
         val builder = ComplicationData.Builder(type)
-        
+
         if (type == ComplicationData.TYPE_SHORT_TEXT) {
             val bgText: String = BloodGlucosePresenter(bg, mmol = mmol, markOld = true, saferUnicode = true).combinedString()
 
@@ -58,13 +60,17 @@ class NightWearComplicationProviderService : ComplicationProviderService() {
         }
 
         if (type == ComplicationData.TYPE_LONG_TEXT) {
-            val bgText: String = BloodGlucosePresenter(bg, mmol = mmol, markOld = false, saferUnicode = true).combinedString() + " (^1)" // the ^1 is interpolated with the age
+            val bgText: String = BloodGlucosePresenter(bg, mmol = mmol, markOld = false, saferUnicode = true).combinedString()
+            val deltaText = bgDelta?.let {
+                " " + BloodGlucoseDeltaPresenter(it, mmol = mmol, showUnits = true).toString()
+            } ?: ""
+            val complicationText = bgText + deltaText + " (^1)" // the ^1 is interpolated with the age
 
-            Log.d(TAG, "updating complication data (LONG_TEXT), bgText: " + bgText)
+            Log.d(TAG, "updating complication data (LONG_TEXT), complicationText: " + complicationText)
 
             builder.setLongText(
                 ComplicationText.TimeDifferenceBuilder()
-                    .setSurroundingText(bgText)
+                    .setSurroundingText(complicationText)
                     .setReferencePeriodStart(bg.sensorTime)
                     .setReferencePeriodEnd(bg.sensorTime)
                     .setShowNowText(false)

--- a/app/src/main/java/im/rah/nightwear/NightWearComplicationProviderService.kt
+++ b/app/src/main/java/im/rah/nightwear/NightWearComplicationProviderService.kt
@@ -39,7 +39,7 @@ class NightWearComplicationProviderService : ComplicationProviderService() {
         val builder = ComplicationData.Builder(type)
         
         if (type == ComplicationData.TYPE_SHORT_TEXT) {
-            val bgText: String = BloodGlucosePresenter(bg, mmol = mmol).combinedString(markOld = true, saferUnicode = true)
+            val bgText: String = BloodGlucosePresenter(bg, mmol = mmol, markOld = true, saferUnicode = true).combinedString()
 
             Log.d(TAG, "updating complication data (SHORT_TEXT), bgText: " + bgText)
 
@@ -58,7 +58,7 @@ class NightWearComplicationProviderService : ComplicationProviderService() {
         }
 
         if (type == ComplicationData.TYPE_LONG_TEXT) {
-            val bgText: String = BloodGlucosePresenter(bg, mmol = mmol).combinedString(markOld = false, saferUnicode = true) + " (^1)" // the ^1 is interpolated with the age
+            val bgText: String = BloodGlucosePresenter(bg, mmol = mmol, markOld = false, saferUnicode = true).combinedString() + " (^1)" // the ^1 is interpolated with the age
 
             Log.d(TAG, "updating complication data (LONG_TEXT), bgText: " + bgText)
 

--- a/app/src/main/java/im/rah/nightwear/NightWearDigitalFace.kt
+++ b/app/src/main/java/im/rah/nightwear/NightWearDigitalFace.kt
@@ -196,7 +196,16 @@ class NightWearDigitalFace : CanvasWatchFaceService() {
             val bgText = BloodGlucosePresenter(bloodGlucoseService.latestBg as BloodGlucose, mmol = mMmol).combinedString()
             canvas.drawText(bgText, mXOffset, mYOffset, mTextPaint)
 
-            if (!mAmbient) {
+            if (mAmbient) {
+                canvas.drawText(bgText, mXOffset, mYOffset, mTextPaint)
+            }
+            else {
+                val deltaText = bloodGlucoseService.latestDelta?.let {
+                    " " + BloodGlucoseDeltaPresenter(it, mmol = mMmol, showUnits = false).toString()
+                } ?: ""
+
+                canvas.drawText(bgText + deltaText, mXOffset, mYOffset, mTextPaint)
+
                 val readingAgeText = bloodGlucoseService.latestReadingAge().toMinutes().toString() + "m"
                 canvas.drawText(readingAgeText, mXOffset, mYOffset + mTextPaint.textSize, mTextPaint)
                 canvas.drawText(timeText(), mXOffset, mYOffset + 2*mTextPaint.textSize, mTextPaint)

--- a/app/src/main/java/im/rah/nightwear/NightWearDigitalFace.kt
+++ b/app/src/main/java/im/rah/nightwear/NightWearDigitalFace.kt
@@ -193,7 +193,7 @@ class NightWearDigitalFace : CanvasWatchFaceService() {
                 return
             }
 
-            val bgText = (bloodGlucoseService.latestBg as BloodGlucose).combinedString(mMmol)
+            val bgText = BloodGlucosePresenter(bloodGlucoseService.latestBg as BloodGlucose).combinedString(mMmol)
             canvas.drawText(bgText, mXOffset, mYOffset, mTextPaint)
 
             if (!mAmbient) {

--- a/app/src/main/java/im/rah/nightwear/NightWearDigitalFace.kt
+++ b/app/src/main/java/im/rah/nightwear/NightWearDigitalFace.kt
@@ -193,7 +193,7 @@ class NightWearDigitalFace : CanvasWatchFaceService() {
                 return
             }
 
-            val bgText = BloodGlucosePresenter(bloodGlucoseService.latestBg as BloodGlucose).combinedString(mMmol)
+            val bgText = BloodGlucosePresenter(bloodGlucoseService.latestBg as BloodGlucose, mmol = mMmol).combinedString()
             canvas.drawText(bgText, mXOffset, mYOffset, mTextPaint)
 
             if (!mAmbient) {

--- a/app/src/main/java/im/rah/nightwear/NightWearTileService.kt
+++ b/app/src/main/java/im/rah/nightwear/NightWearTileService.kt
@@ -49,6 +49,7 @@ class NightWearTileService : TileService() {
 
         val deviceParams = requestParams.deviceParameters!!
         val bg = bloodGlucoseService.latestBg
+        val bgDelta = bloodGlucoseService.latestDelta
 
         Tile.Builder()
             .setResourcesVersion(RESOURCES_VERSION)
@@ -60,7 +61,7 @@ class NightWearTileService : TileService() {
                             .setLayout(
                                 Layout.Builder()
                                     .setRoot(
-                                        layout(bg, deviceParams)
+                                        layout(bg, bgDelta, deviceParams)
                                     )
                                     .build()
                             )
@@ -70,7 +71,7 @@ class NightWearTileService : TileService() {
             ).build()
     }
 
-    private fun layout(bloodGlucose: BloodGlucose?, deviceParameters: DeviceParameters) =
+    private fun layout(bloodGlucose: BloodGlucose?, bloodGlucoseDelta: BloodGlucoseDelta?, deviceParameters: DeviceParameters) =
         Box.Builder()
             .setWidth(expand())
             .setHeight(expand())
@@ -78,7 +79,7 @@ class NightWearTileService : TileService() {
             .addContent(
                 Column.Builder()
                     .addContent(currentBloodGlucoseText(bloodGlucose, deviceParameters))
-                    .addContent(bloodGlucoseUnitText(deviceParameters))
+                    .addContent(currentBloodGlucoseDeltaText(bloodGlucoseDelta, deviceParameters))
                     .addContent(readingAgeText(bloodGlucose, deviceParameters))
                     .build())
             .build()
@@ -131,13 +132,15 @@ class NightWearTileService : TileService() {
             .build()
     }
 
-    private fun bloodGlucoseUnitText(deviceParameters: DeviceParameters): Text {
+    private fun currentBloodGlucoseDeltaText(bgDelta: BloodGlucoseDelta?, deviceParameters: DeviceParameters): Text {
         val prefs = PreferenceManager.getDefaultSharedPreferences(this.applicationContext)
-        val unit = if (prefs.getBoolean("mmol", true)) BloodGlucose.Unit.MMOL.label
-                   else BloodGlucose.Unit.MGDL.label
+        val mmol = prefs.getBoolean("mmol", true)
+        val text = bgDelta?.let {
+            BloodGlucoseDeltaPresenter(it, mmol = mmol, showUnits = true).toString()
+        } ?: getString(R.string.bg_placeholder)
 
         return Text.Builder()
-            .setText(unit)
+            .setText(text)
             .setFontStyle(FontStyles.title3(deviceParameters).build())
             .build()
     }

--- a/app/src/main/java/im/rah/nightwear/NightWearTileService.kt
+++ b/app/src/main/java/im/rah/nightwear/NightWearTileService.kt
@@ -107,7 +107,9 @@ class NightWearTileService : TileService() {
     private fun currentBloodGlucoseText(bg: BloodGlucose?, deviceParameters: DeviceParameters): Text {
         val prefs = PreferenceManager.getDefaultSharedPreferences(this.applicationContext)
         val mmol = prefs.getBoolean("mmol", true)
-        val text = bg?.combinedString(mmol) ?: getString(R.string.bg_placeholder)
+        val text = bg?.let {
+            BloodGlucosePresenter(it, mmol = mmol).combinedString()
+        } ?: getString(R.string.bg_placeholder)
 
         return Text.Builder()
             .setText(text)

--- a/app/src/test/java/im/rah/nightwear/BloodGlucoseDeltaPresenterTest.kt
+++ b/app/src/test/java/im/rah/nightwear/BloodGlucoseDeltaPresenterTest.kt
@@ -27,7 +27,7 @@ class BloodGlucoseDeltaPresenterTest {
     fun `mgdl zero`() {
         assertThat(
             BloodGlucoseDeltaPresenter(deltaInMgdl(0), mmol = false).toString()
-        ).isEqualTo("0 mg/dL")
+        ).isEqualTo("+0 mg/dL")
     }
 
     @Test
@@ -68,10 +68,10 @@ class BloodGlucoseDeltaPresenterTest {
     }
 
     @Test
-    fun `mmol zero has no sign`() {
+    fun `mmol zero shows plus sign`() {
         assertThat(
             BloodGlucoseDeltaPresenter(deltaInMmol(0.0),true).toString()
-        ).isEqualTo("0.0 mmol/L")
+        ).isEqualTo("+0.0 mmol/L")
     }
 
     private fun bgInMgdl(mgdl : Int) =

--- a/app/src/test/java/im/rah/nightwear/BloodGlucoseDeltaPresenterTest.kt
+++ b/app/src/test/java/im/rah/nightwear/BloodGlucoseDeltaPresenterTest.kt
@@ -12,66 +12,72 @@ class BloodGlucoseDeltaPresenterTest {
     @Test
     fun `mgdl positive`() {
         assertThat(
-            BloodGlucoseDeltaPresenter(BloodGlucoseDelta(42),false).toString()
-        ).isEqualTo("+42")
+            BloodGlucoseDeltaPresenter(deltaInMgdl(42),false).toString()
+        ).isEqualTo("+42 mg/dL")
     }
 
     @Test
     fun `mgdl negative`() {
         assertThat(
-            BloodGlucoseDeltaPresenter(BloodGlucoseDelta(-42),false).toString()
-        ).isEqualTo("-42")
+            BloodGlucoseDeltaPresenter(deltaInMgdl(-42),false).toString()
+        ).isEqualTo("-42 mg/dL")
     }
 
     @Test
     fun `mgdl zero`() {
         assertThat(
-            BloodGlucoseDeltaPresenter(BloodGlucoseDelta(0),false).toString()
-        ).isEqualTo("0")
+            BloodGlucoseDeltaPresenter(deltaInMgdl(0),false).toString()
+        ).isEqualTo("0 mg/dL")
     }
 
     // mmol/L ---------------------
 
     @Test
     fun `mmol positive more than 1`() {
-        val mgdl = (2.3*MMOLL_TO_MGDL).roundToInt()
         assertThat(
-            BloodGlucoseDeltaPresenter(BloodGlucoseDelta(mgdl),true).toString()
-        ).isEqualTo("+2.3")
+            BloodGlucoseDeltaPresenter(deltaInMmol(2.3),true).toString()
+        ).isEqualTo("+2.3 mmol/L")
     }
 
     @Test
     fun `mmol positive smaller than 1`() {
-        val mgdl = (0.1*MMOLL_TO_MGDL).roundToInt()
         assertThat(
-            BloodGlucoseDeltaPresenter(BloodGlucoseDelta(mgdl),true).toString()
-        ).isEqualTo("+0.1")
+            BloodGlucoseDeltaPresenter(deltaInMmol(0.1),true).toString()
+        ).isEqualTo("+0.1 mmol/L")
     }
 
     @Test
     fun `mmol negative greater than 1`() {
-        val mgdl = (-2.3*MMOLL_TO_MGDL).roundToInt()
         assertThat(
-            BloodGlucoseDeltaPresenter(BloodGlucoseDelta(mgdl),true).toString()
-        ).isEqualTo("-2.3")
+            BloodGlucoseDeltaPresenter(deltaInMmol(-2.3),true).toString()
+        ).isEqualTo("-2.3 mmol/L")
     }
 
     @Test
     fun `mmol negative smaller than -1`() {
-        val mgdl = (-0.1*MMOLL_TO_MGDL).roundToInt()
         assertThat(
-            BloodGlucoseDeltaPresenter(BloodGlucoseDelta(mgdl),true).toString()
-        ).isEqualTo("-0.1")
+            BloodGlucoseDeltaPresenter(deltaInMmol(-0.1),true).toString()
+        ).isEqualTo("-0.1 mmol/L")
     }
 
     @Test
     fun `mmol zero has no sign`() {
         assertThat(
-            BloodGlucoseDeltaPresenter(BloodGlucoseDelta(0),true).toString()
-        ).isEqualTo("0.0")
+            BloodGlucoseDeltaPresenter(deltaInMmol(0.0),true).toString()
+        ).isEqualTo("0.0 mmol/L")
     }
 
-    // With decimal mg/dL values there would be an edge case where a non-zero value converted to
-    // 0.0mmol/L, but would still show a sign. We don't need to worry about that because 1mg/dL
-    // rounds to 0.1mmol/L.
+    private fun bgInMgdl(mgdl : Int) =
+        BloodGlucose(mgdl, direction = BloodGlucose.Direction.NONE, sensorTime = 0)
+
+    private fun bgInMmol(mmol : Double) : BloodGlucose {
+        val mgdl = (mmol*MMOLL_TO_MGDL).roundToInt()
+        return BloodGlucose(mgdl, direction = BloodGlucose.Direction.NONE, sensorTime = 0)
+    }
+
+    private fun deltaInMgdl(mgdl : Int) : BloodGlucoseDelta =
+        BloodGlucoseDelta(bgInMgdl(0), bgInMgdl(0 + mgdl))
+
+    private fun deltaInMmol(mmol : Double) : BloodGlucoseDelta =
+        BloodGlucoseDelta(bgInMmol(0.0), bgInMmol(0.0 + mmol))
 }

--- a/app/src/test/java/im/rah/nightwear/BloodGlucoseDeltaPresenterTest.kt
+++ b/app/src/test/java/im/rah/nightwear/BloodGlucoseDeltaPresenterTest.kt
@@ -12,22 +12,29 @@ class BloodGlucoseDeltaPresenterTest {
     @Test
     fun `mgdl positive`() {
         assertThat(
-            BloodGlucoseDeltaPresenter(deltaInMgdl(42),false).toString()
+            BloodGlucoseDeltaPresenter(deltaInMgdl(42), mmol = false).toString()
         ).isEqualTo("+42 mg/dL")
     }
 
     @Test
     fun `mgdl negative`() {
         assertThat(
-            BloodGlucoseDeltaPresenter(deltaInMgdl(-42),false).toString()
+            BloodGlucoseDeltaPresenter(deltaInMgdl(-42), mmol = false).toString()
         ).isEqualTo("-42 mg/dL")
     }
 
     @Test
     fun `mgdl zero`() {
         assertThat(
-            BloodGlucoseDeltaPresenter(deltaInMgdl(0),false).toString()
+            BloodGlucoseDeltaPresenter(deltaInMgdl(0), mmol = false).toString()
         ).isEqualTo("0 mg/dL")
+    }
+
+    @Test
+    fun `mgdl units hidden`() {
+        assertThat(
+            BloodGlucoseDeltaPresenter(deltaInMgdl(42), mmol = false, showUnits = false).toString()
+        ).isEqualTo("+42")
     }
 
     // mmol/L ---------------------

--- a/app/src/test/java/im/rah/nightwear/BloodGlucoseDeltaPresenterTest.kt
+++ b/app/src/test/java/im/rah/nightwear/BloodGlucoseDeltaPresenterTest.kt
@@ -1,0 +1,77 @@
+package im.rah.nightwear
+
+import com.google.common.truth.Truth.assertThat
+import im.rah.nightwear.BloodGlucose.Companion.MMOLL_TO_MGDL
+import org.junit.Test
+import kotlin.math.roundToInt
+
+class BloodGlucoseDeltaPresenterTest {
+
+    // mg/dL ---------------------
+
+    @Test
+    fun `mgdl positive`() {
+        assertThat(
+            BloodGlucoseDeltaPresenter(BloodGlucoseDelta(42),false).toString()
+        ).isEqualTo("+42")
+    }
+
+    @Test
+    fun `mgdl negative`() {
+        assertThat(
+            BloodGlucoseDeltaPresenter(BloodGlucoseDelta(-42),false).toString()
+        ).isEqualTo("-42")
+    }
+
+    @Test
+    fun `mgdl zero`() {
+        assertThat(
+            BloodGlucoseDeltaPresenter(BloodGlucoseDelta(0),false).toString()
+        ).isEqualTo("0")
+    }
+
+    // mmol/L ---------------------
+
+    @Test
+    fun `mmol positive more than 1`() {
+        val mgdl = (2.3*MMOLL_TO_MGDL).roundToInt()
+        assertThat(
+            BloodGlucoseDeltaPresenter(BloodGlucoseDelta(mgdl),true).toString()
+        ).isEqualTo("+2.3")
+    }
+
+    @Test
+    fun `mmol positive smaller than 1`() {
+        val mgdl = (0.1*MMOLL_TO_MGDL).roundToInt()
+        assertThat(
+            BloodGlucoseDeltaPresenter(BloodGlucoseDelta(mgdl),true).toString()
+        ).isEqualTo("+0.1")
+    }
+
+    @Test
+    fun `mmol negative greater than 1`() {
+        val mgdl = (-2.3*MMOLL_TO_MGDL).roundToInt()
+        assertThat(
+            BloodGlucoseDeltaPresenter(BloodGlucoseDelta(mgdl),true).toString()
+        ).isEqualTo("-2.3")
+    }
+
+    @Test
+    fun `mmol negative smaller than -1`() {
+        val mgdl = (-0.1*MMOLL_TO_MGDL).roundToInt()
+        assertThat(
+            BloodGlucoseDeltaPresenter(BloodGlucoseDelta(mgdl),true).toString()
+        ).isEqualTo("-0.1")
+    }
+
+    @Test
+    fun `mmol zero has no sign`() {
+        assertThat(
+            BloodGlucoseDeltaPresenter(BloodGlucoseDelta(0),true).toString()
+        ).isEqualTo("0.0")
+    }
+
+    // With decimal mg/dL values there would be an edge case where a non-zero value converted to
+    // 0.0mmol/L, but would still show a sign. We don't need to worry about that because 1mg/dL
+    // rounds to 0.1mmol/L.
+}

--- a/app/src/test/java/im/rah/nightwear/BloodGlucoseDeltaTest.kt
+++ b/app/src/test/java/im/rah/nightwear/BloodGlucoseDeltaTest.kt
@@ -1,0 +1,29 @@
+package im.rah.nightwear
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import kotlin.math.roundToInt
+
+class BloodGlucoseDeltaTest {
+    @Test
+    fun `#inMgdl is a simple subtraction`() {
+        val bg1 = BloodGlucose(84, direction = BloodGlucose.Direction.NONE, sensorTime = 0)
+        val bg2 = BloodGlucose(42, direction = BloodGlucose.Direction.NONE, sensorTime = 0)
+
+        assertThat(
+            BloodGlucoseDelta(bg1, bg2).inMgdl()
+        ).isEqualTo(-42)
+    }
+
+    @Test
+    fun `#inMgdl is the post rounded difference`() {
+        val mgdl1 = (4.2* BloodGlucose.MMOLL_TO_MGDL).roundToInt()
+        val mgdl2 = (8.4* BloodGlucose.MMOLL_TO_MGDL).roundToInt()
+        val bg1 = BloodGlucose(mgdl1, direction = BloodGlucose.Direction.NONE, sensorTime = 0)
+        val bg2 = BloodGlucose(mgdl2, direction = BloodGlucose.Direction.NONE, sensorTime = 0)
+
+        assertThat(
+            BloodGlucoseDelta(bg1, bg2).inMmol()
+        ).isEqualTo(4.2)
+    }
+}

--- a/app/src/test/java/im/rah/nightwear/BloodGlucosePresenterTest.kt
+++ b/app/src/test/java/im/rah/nightwear/BloodGlucosePresenterTest.kt
@@ -1,0 +1,69 @@
+package im.rah.nightwear
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.time.Duration
+import java.time.Instant
+import kotlin.math.roundToInt
+
+class BloodGlucosePresenterTest {
+
+    @Test
+    fun `#combinedString mgdl Flat`() {
+        val bg = BloodGlucose(42, 1546896050000, BloodGlucose.Direction.Flat)
+        assertThat(
+            BloodGlucosePresenter(bg, false).combinedString()
+        ).isEqualTo("42 ➡")
+    }
+
+    @Test
+    fun `#combinedString mgdl FortyFiveUp`() {
+        val bg = BloodGlucose(42, 1546896050000, BloodGlucose.Direction.FortyFiveUp)
+        assertThat(
+            BloodGlucosePresenter(bg, false).combinedString()
+        ).isEqualTo("42 ⬈")
+    }
+
+    @Test
+    fun `#combinedString mgdl DoubleUp`() {
+        val bg = BloodGlucose(42, 1546896050000, BloodGlucose.Direction.DoubleUp)
+        assertThat(
+            BloodGlucosePresenter(bg, false).combinedString()
+        ).isEqualTo("42 ⬆⬆")
+    }
+
+    @Test
+    fun `#combinedString mgdl DoubleUp safer unicode`() {
+        val bg = BloodGlucose(42, 1546896050000, BloodGlucose.Direction.DoubleUp)
+        assertThat(
+            BloodGlucosePresenter(bg, mmol = false, saferUnicode = true).combinedString()
+        ).isEqualTo("42 ⇧⇧")
+    }
+
+    @Test
+    fun `#combinedString mmol`() {
+        val mgdl = (4.2* BloodGlucose.MMOLL_TO_MGDL).roundToInt()
+        val bg = BloodGlucose(mgdl, 1546896050000, BloodGlucose.Direction.Flat)
+        assertThat(
+            BloodGlucosePresenter(bg, true).combinedString()
+        ).isEqualTo("4.2 ➡")
+    }
+
+    @Test
+    fun `#combinedString mgdl mark old, older than 11 minutes`() {
+        val timestamp = Instant.now().minus(Duration.ofMinutes(15)).toEpochMilli()
+        val bg = BloodGlucose(42, timestamp, BloodGlucose.Direction.Flat)
+        assertThat(
+            BloodGlucosePresenter(bg, false, markOld = true).combinedString()
+        ).isEqualTo("42 OLD")
+    }
+
+    @Test
+    fun `#combinedString mgdl mark old, newer than 11 minutes`() {
+        val timestamp = Instant.now().minus(Duration.ofMinutes(5)).toEpochMilli()
+        val bg = BloodGlucose(42, timestamp, BloodGlucose.Direction.Flat)
+        assertThat(
+            BloodGlucosePresenter(bg, false, markOld = true).combinedString()
+        ).isEqualTo("42 ➡")
+    }
+}

--- a/app/src/test/java/im/rah/nightwear/BloodGlucoseTest.kt
+++ b/app/src/test/java/im/rah/nightwear/BloodGlucoseTest.kt
@@ -26,4 +26,28 @@ class BloodGlucoseTest {
         assertThat(bloodGlucose?.sensorTime).isEqualTo(1546896050000)
     }
 
+    @Test
+    fun testParseTabSeparatedRecent() {
+        val exampleResponse =
+            """
+            "2020-10-26T22:08:21.000Z"	1603750101000	73	"NOT COMPUTABLE"	"share2"
+            "2020-10-26T22:03:21.000Z"	1603749801000	67	"NOT COMPUTABLE"	"share2"
+            "2020-10-26T21:48:22.000Z"	1603748902000	53	"Flat"	"share2"
+            "2020-10-26T21:43:21.000Z"	1603748601000	69	"Flat"	"share2"
+            "2020-10-26T21:38:21.000Z"	1603748301000	85	"Flat"	"share2"
+            "2020-10-26T21:33:22.000Z"	1603748002000	84	"FortyFiveDown"	"share2"
+            "2020-10-26T21:28:21.000Z"	1603747701000	85	"Flat"	"share2"
+            "2020-10-26T21:23:21.000Z"	1603747401000	87	"Flat"	"share2"
+            "2020-10-26T21:18:21.000Z"	1603747101000	89	"Flat"	"share2"
+            "2020-10-26T21:13:21.000Z"	1603746801000	91	"Flat"	"share2"
+            """.trimIndent()
+
+        val recentBloodGlucoseArray = BloodGlucose.parseTabSeparatedRecent(exampleResponse)
+
+        assertThat(recentBloodGlucoseArray.size).isEqualTo(10)
+
+        assertThat(recentBloodGlucoseArray.first()?.glucoseLevel_mgdl).isEqualTo(73)
+        assertThat(recentBloodGlucoseArray.first()?.direction).isEqualTo(BloodGlucose.Direction.NOT_COMPUTABLE)
+        assertThat(recentBloodGlucoseArray.first()?.sensorTime).isEqualTo(1603750101000)
+    }
 }


### PR DESCRIPTION
Resolves #2 

This:
- adds support to `BloodGlucoseService` to read from the recent entries endpoint so that we have access to both the current and penultimate readings for comparison.
- updates the Watch Face, Tile and Complication to all include the delta information

<img src="https://user-images.githubusercontent.com/14014/166838192-088d190d-48f2-438f-aa4f-5735e27b744b.png" width="380px">

<img src="https://user-images.githubusercontent.com/14014/166838133-7b099100-a3a9-48bd-81da-4a249675af11.png" width="380px">

<img src="https://user-images.githubusercontent.com/14014/166838044-72e1b4b8-72ee-4854-866b-06f91ad70975.png" width="380px">


