### PR TITLE
Token auth support

### DIFF
--- a/app/src/main/java/im/rah/nightwear/BloodGlucoseService.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucoseService.kt
@@ -5,9 +5,6 @@ import android.content.SharedPreferences
 import androidx.preference.PreferenceManager
 import android.support.wearable.complications.ProviderUpdateRequester
 import android.util.Log
-import com.android.volley.Request
-import com.android.volley.RequestQueue
-import com.android.volley.Response
 import com.android.volley.toolbox.StringRequest
 import com.android.volley.toolbox.Volley
 import org.threeten.bp.Duration
@@ -16,6 +13,8 @@ import java.text.ParseException
 import java.util.*
 import kotlin.concurrent.schedule
 import android.content.ComponentName
+import com.android.volley.*
+import com.google.common.hash.Hashing
 
 class BloodGlucoseService(context: Context) : SharedPreferences.OnSharedPreferenceChangeListener {
     var recentEntries:List<BloodGlucose?> = List<BloodGlucose?>(0) { null }
@@ -31,6 +30,7 @@ class BloodGlucoseService(context: Context) : SharedPreferences.OnSharedPreferen
     var onDataUpdateListeners: MutableList<(BloodGlucose)->Unit> = mutableListOf()
 
     private var nightscoutBaseUrl = ""
+    private var nightscoutApiSecret = ""
     private val requestQueue: RequestQueue = Volley.newRequestQueue(context)
     private var prefs: SharedPreferences
     private var lastRequestAdded: Instant = Instant.EPOCH
@@ -57,7 +57,8 @@ class BloodGlucoseService(context: Context) : SharedPreferences.OnSharedPreferen
         prefs = PreferenceManager.getDefaultSharedPreferences(context.applicationContext)
         prefs.registerOnSharedPreferenceChangeListener(this)
         nightscoutBaseUrl = prefs.getString("nightscoutBaseUrl", "")!!
-
+        nightscoutApiSecret = prefs.getString("nightscoutApiSecret", "")!!
+        
         Timer().schedule(0, 1000 * 15) { refresh() }
 
         addDataUpdateListener {
@@ -89,10 +90,17 @@ class BloodGlucoseService(context: Context) : SharedPreferences.OnSharedPreferen
         if (key == "nightscoutBaseUrl") {
             nightscoutBaseUrl = prefs.getString("nightscoutBaseUrl", "")!!
         }
+        if (key == "nightscoutApiSecret") {
+            nightscoutApiSecret = prefs.getString("nightscoutApiSecret", "")!!
+        }
     }
 
     private fun nsRecentEntriesUrl() : String {
         return nightscoutBaseUrl + NS_RECENT_ENTRIES_PATH
+    }
+
+    private fun nsSha1HashedSecret() : String {
+        return Hashing.sha1().hashString(nightscoutApiSecret,Charsets.UTF_8).toString()
     }
 
     fun refresh(force: Boolean = false) {
@@ -112,12 +120,16 @@ class BloodGlucoseService(context: Context) : SharedPreferences.OnSharedPreferen
         // don't make requests more than once every 30s
         if (Duration.between(lastRequestAdded, Instant.now()) < Duration.ofSeconds(30)) return
 
-        Log.d(tag, "clearing queue, then requesting, nightscoutBaseUrl: " + nightscoutBaseUrl)
+        Log.d(tag, "clearing queue, then requesting")
+        Log.d(tag, "  nightscoutBaseUrl: " + nightscoutBaseUrl)
+        Log.d(tag, "  nightscoutApiSecret: " + nightscoutApiSecret)
+        Log.d(tag, "  nsSha1HashedSecret: " + nsSha1HashedSecret())
+
         requestQueue.cancelAll(this)
 
         lastRequestAdded = Instant.now()
-        val stringRequest = StringRequest(
-            Request.Method.GET, nsRecentEntriesUrl(),
+        val stringRequest = object: StringRequest(
+            Method.GET, nsRecentEntriesUrl(),
             { response ->
                 Log.d(tag, "recent bgs received, parsing...")
                 try {
@@ -129,12 +141,28 @@ class BloodGlucoseService(context: Context) : SharedPreferences.OnSharedPreferen
                     }
                 }
                 catch (e: ParseException) {
+                    // TODO: see error handling comment below
                     Log.d(tag, "ParseException for response: " + response)
                 }
             },
             {
-                Log.d(tag, "request error")
+                // TODO: it would be nice to do something with the UI state to indicate a problem
+                //       In the most common case slightly stale data is still useful, so what we
+                //       choose to show shouldn't obscure that.
+                Log.d(tag, "request error: " + it.toString())
             })
+            {
+                @Throws(AuthFailureError::class)
+                override fun getHeaders(): Map<String, String> {
+                    val headers = HashMap<String, String>()
+
+                    if (nightscoutApiSecret != "") {
+                        Log.d(TAG, "adding API-SECRET header")
+                        headers.put("API-SECRET", nsSha1HashedSecret())
+                    }
+                    return headers
+                }
+            }
         stringRequest.tag = this
 
         // Add the request to the RequestQueue.

--- a/app/src/main/java/im/rah/nightwear/BloodGlucoseService.kt
+++ b/app/src/main/java/im/rah/nightwear/BloodGlucoseService.kt
@@ -58,7 +58,7 @@ class BloodGlucoseService(context: Context) : SharedPreferences.OnSharedPreferen
         prefs.registerOnSharedPreferenceChangeListener(this)
         nightscoutBaseUrl = prefs.getString("nightscoutBaseUrl", "")!!
         nightscoutApiSecret = prefs.getString("nightscoutApiSecret", "")!!
-        
+
         Timer().schedule(0, 1000 * 15) { refresh() }
 
         addDataUpdateListener {

--- a/app/src/main/java/im/rah/nightwear/ConfigurationActivity.kt
+++ b/app/src/main/java/im/rah/nightwear/ConfigurationActivity.kt
@@ -27,6 +27,7 @@ class ConfigurationActivity : WearableActivity() {
     private lateinit var urlTextView:TextView
     private lateinit var domainEditText:EditText
     private lateinit var tldSpinner:Spinner
+    private lateinit var apiSecretEditText:EditText
     private lateinit var confirmButton:Button
     private lateinit var unitToggleButton:ToggleButton
     private lateinit var timeFormatToggleButton:ToggleButton
@@ -48,6 +49,7 @@ class ConfigurationActivity : WearableActivity() {
 
         domainEditText = findViewById(R.id.domain)
         urlTextView = findViewById(R.id.url)
+        apiSecretEditText = findViewById(R.id.api_secret)
 
         tldSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onItemSelected(parentView: AdapterView<*>, selectedItemView: View, position: Int, id: Long) {
@@ -77,7 +79,7 @@ class ConfigurationActivity : WearableActivity() {
         confirmButton.setOnClickListener {
             thread {
                 if (urlValid()) {
-                    persistUrl()
+                    persistUrlAndSecret()
                     setResult(Activity.RESULT_OK)
                     finish()
                 }
@@ -96,6 +98,7 @@ class ConfigurationActivity : WearableActivity() {
         timeFormatToggleButton.setOnClickListener { persistTimeFormat() }
 
         loadUrlFromPrefs()
+        loadSecretFromPrefs()
         loadUnitFromPrefs()
         loadTimeFormatFromPrefs()
 
@@ -112,6 +115,11 @@ class ConfigurationActivity : WearableActivity() {
         val adapter = tldSpinner.adapter as ArrayAdapter<String>
         val tldPosition = adapter.getPosition(tld)
         tldSpinner.setSelection(tldPosition)
+    }
+
+    private fun loadSecretFromPrefs() {
+        val secret = prefs.getString("nightscoutApiSecret", "")
+        apiSecretEditText.setText(secret)
     }
 
     private fun loadUnitFromPrefs() {
@@ -147,13 +155,20 @@ class ConfigurationActivity : WearableActivity() {
         }
     }
 
-    private fun persistUrl() {
-        Log.d(TAG, "persistUrl")
+    private fun persistUrlAndSecret() {
+        Log.d(TAG, "persistUrlAndSecret")
         val url = url()
         if (prefs.getString("nighscoutBaseUrl", "") != url) {
             Log.d(TAG, "updating nighscoutBaseUrl pref")
             val edit = prefs.edit()
             edit.putString("nightscoutBaseUrl", url())
+            edit.apply()
+        }
+        val secret:String = "" + apiSecretEditText.text
+        if (prefs.getString("nighscoutApiSecret", "") != secret) {
+            Log.d(TAG, "updating nighscoutApiSecret pref")
+            val edit = prefs.edit()
+            edit.putString("nightscoutApiSecret", secret)
             edit.apply()
         }
     }
@@ -180,7 +195,11 @@ class ConfigurationActivity : WearableActivity() {
         }
     }
 
+    // TODO: update this to allow for the secret
+    //       ideally we'd differentiate the toast if we detect unauthorized headers...
     private fun urlValid() : Boolean {
+        return true //FIXME!
+
         return try {
             URL(url() + "/api/v1/status.json").readText().contains("nightscout")
         } catch (e : IOException) {

--- a/app/src/main/java/im/rah/nightwear/ConfigurationActivity.kt
+++ b/app/src/main/java/im/rah/nightwear/ConfigurationActivity.kt
@@ -25,9 +25,10 @@ class ConfigurationActivity : WearableActivity() {
     private lateinit var domainEditText:EditText
     private lateinit var tldSpinner:Spinner
     private lateinit var apiSecretEditText:EditText
-    private lateinit var confirmButton:Button
     private lateinit var unitToggleButton:ToggleButton
     private lateinit var timeFormatToggleButton:ToggleButton
+    private lateinit var confirmButton:Button
+    private lateinit var progress:ProgressBar
 
     private lateinit var prefs:SharedPreferences
 
@@ -74,6 +75,8 @@ class ConfigurationActivity : WearableActivity() {
 
         confirmButton = findViewById(R.id.confirm_button)
         confirmButton.setOnClickListener { handleUrlConfirmation() }
+
+        progress = findViewById(R.id.progress)
 
         unitToggleButton = findViewById(R.id.unit_toggle_button)
         unitToggleButton.setOnClickListener { persistUnit() }
@@ -179,6 +182,9 @@ class ConfigurationActivity : WearableActivity() {
     private val secret get() = "" + apiSecretEditText.text
 
     private fun handleUrlConfirmation() {
+        confirmButton.visibility = View.GONE
+        progress.visibility = View.VISIBLE
+
         val validator = NightScoutDomainValidator(this, url, secret)
         validator.onValidation {
             Log.d(TAG, "domain validated: " + it)
@@ -191,6 +197,8 @@ class ConfigurationActivity : WearableActivity() {
             Log.d(TAG, "domain validation auth error ")
 
             this.runOnUiThread {
+                confirmButton.visibility = View.VISIBLE
+                progress.visibility = View.GONE
                 Toast.makeText(this, "Authentication failed\nCheck Secret", Toast.LENGTH_LONG).show()
             }
         }
@@ -198,6 +206,8 @@ class ConfigurationActivity : WearableActivity() {
             Log.d(TAG, "domain validationError " + it.javaClass + " " + it.message)
 
             this.runOnUiThread {
+                confirmButton.visibility = View.VISIBLE
+                progress.visibility = View.GONE
                 Toast.makeText(this, "Connection failed: ${url}", Toast.LENGTH_LONG).show()
             }
         }

--- a/app/src/main/java/im/rah/nightwear/ConfigurationActivity.kt
+++ b/app/src/main/java/im/rah/nightwear/ConfigurationActivity.kt
@@ -87,20 +87,7 @@ class ConfigurationActivity : WearableActivity() {
         })
 
         confirmButton = findViewById(R.id.confirm_button)
-        confirmButton.setOnClickListener {
-            thread {
-                if (urlValid()) {
-                    persistUrlAndSecret()
-                    setResult(Activity.RESULT_OK)
-                    finish()
-                }
-                else {
-                    this.runOnUiThread {
-                        Toast.makeText(this, "Invalid URL: ${url()}", Toast.LENGTH_LONG).show()
-                    }
-                }
-            }
-        }
+        confirmButton.setOnClickListener { handleUrlConfirmation() }
 
         unitToggleButton = findViewById(R.id.unit_toggle_button)
         unitToggleButton.setOnClickListener { persistUnit() }
@@ -203,6 +190,21 @@ class ConfigurationActivity : WearableActivity() {
             scheme + domainEditText.text + "." + tldSpinner.selectedItem
         } else {
             scheme + domainEditText.text
+        }
+    }
+
+    private fun handleUrlConfirmation() {
+        thread {
+            if (urlValid()) {
+                persistUrlAndSecret()
+                setResult(Activity.RESULT_OK)
+                finish()
+            }
+            else {
+                this.runOnUiThread {
+                    Toast.makeText(this, "Invalid URL: ${url()}", Toast.LENGTH_LONG).show()
+                }
+            }
         }
     }
 

--- a/app/src/main/java/im/rah/nightwear/ConfigurationActivity.kt
+++ b/app/src/main/java/im/rah/nightwear/ConfigurationActivity.kt
@@ -91,19 +91,19 @@ class ConfigurationActivity : WearableActivity() {
     }
 
     private fun loadUrlFromPrefs() {
-        val url = prefs.getString("nightscoutBaseUrl", DEFAULT_URL)!!
-        val domain = domainFromUrl(url)
+        val urlFromPrefs = prefs.getString("nightscoutBaseUrl", DEFAULT_URL)!!
+        val domain = domainFromUrl(urlFromPrefs)
         domainEditText.setText(domain)
 
-        val tld = tldFromUrl(url)
+        val tld = tldFromUrl(urlFromPrefs)
         val adapter = tldSpinner.adapter as ArrayAdapter<String>
         val tldPosition = adapter.getPosition(tld)
         tldSpinner.setSelection(tldPosition)
     }
 
     private fun loadSecretFromPrefs() {
-        val secret = prefs.getString("nightscoutApiSecret", "")
-        apiSecretEditText.setText(secret)
+        val secretFromPrefs = prefs.getString("nightscoutApiSecret", "")
+        apiSecretEditText.setText(secretFromPrefs)
     }
 
     private fun loadUnitFromPrefs() {
@@ -132,7 +132,6 @@ class ConfigurationActivity : WearableActivity() {
 
     private fun refreshUrlText() {
         Log.d(TAG, "refreshUrlText")
-        val url = url()
         if (urlTextView.text != url) {
             Log.d(TAG, "updating urlTextView")
             urlTextView.text = url
@@ -142,17 +141,16 @@ class ConfigurationActivity : WearableActivity() {
     private fun persistUrlAndSecret() {
         Log.d(TAG, "persistUrlAndSecret")
 
-        val url = url()
         if (prefs.getString("nighscoutBaseUrl", null) != url) {
             Log.d(TAG, "updating nighscoutBaseUrl pref to: " + url)
             val edit = prefs.edit()
-            edit.putString("nightscoutBaseUrl", url())
+            edit.putString("nightscoutBaseUrl", url)
             edit.apply()
         }
-        if (prefs.getString("nighscoutApiSecret", null) != nightscoutApiSecret) {
-            Log.d(TAG, "updating nighscoutApiSecret pref to: " + nightscoutApiSecret)
+        if (prefs.getString("nighscoutApiSecret", null) != secret) {
+            Log.d(TAG, "updating nighscoutApiSecret pref to: " + secret)
             val edit = prefs.edit()
-            edit.putString("nightscoutApiSecret", nightscoutApiSecret)
+            edit.putString("nightscoutApiSecret", secret)
             edit.apply()
         }
     }
@@ -171,17 +169,17 @@ class ConfigurationActivity : WearableActivity() {
         edit.apply()
     }
 
-    private fun url() : String {
+    private val url get() : String {
         return if (tldSpinner.selectedItem in COMMON_TLDS) {
             scheme + domainEditText.text + "." + tldSpinner.selectedItem
         } else {
             scheme + domainEditText.text
         }
     }
-    private val nightscoutApiSecret get() = "" + apiSecretEditText.text
+    private val secret get() = "" + apiSecretEditText.text
 
     private fun handleUrlConfirmation() {
-        val validator = NightScoutDomainValidator(this, url(), nightscoutApiSecret)
+        val validator = NightScoutDomainValidator(this, url, secret)
         validator.onValidation {
             Log.d(TAG, "domain validated: " + it)
 
@@ -200,7 +198,7 @@ class ConfigurationActivity : WearableActivity() {
             Log.d(TAG, "domain validationError " + it.javaClass + " " + it.message)
 
             this.runOnUiThread {
-                Toast.makeText(this, "Connection failed: ${url()}", Toast.LENGTH_LONG).show()
+                Toast.makeText(this, "Connection failed: ${url}", Toast.LENGTH_LONG).show()
             }
         }
         validator.run()

--- a/app/src/main/java/im/rah/nightwear/ConfigurationActivity.kt
+++ b/app/src/main/java/im/rah/nightwear/ConfigurationActivity.kt
@@ -262,6 +262,10 @@ class ConfigurationActivity : WearableActivity() {
             Log.d(TAG, "cause: " + e.cause.toString())
             return false
         }
+        catch(e: InterruptedException) {
+            Log.d(TAG, "InterruptedException: " + e.message)
+            return false
+        }
         catch(e: Exception) {
             Log.d(TAG, "Unexpected Exception: " + e.javaClass)
             return false

--- a/app/src/main/java/im/rah/nightwear/ConfigurationActivity.kt
+++ b/app/src/main/java/im/rah/nightwear/ConfigurationActivity.kt
@@ -15,15 +15,10 @@ import com.android.volley.toolbox.RequestFuture
 import com.android.volley.toolbox.StringRequest
 import com.android.volley.toolbox.Volley
 import com.google.common.hash.Hashing
-import org.json.JSONObject
-import java.io.IOException
-import java.net.URL
-import java.text.ParseException
 import java.util.HashMap
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
-import kotlin.concurrent.thread
 
 class ConfigurationActivity : WearableActivity() {
 
@@ -194,81 +189,24 @@ class ConfigurationActivity : WearableActivity() {
     }
 
     private fun handleUrlConfirmation() {
-        thread {
-            if (urlValid()) {
-                persistUrlAndSecret()
-                setResult(Activity.RESULT_OK)
-                finish()
-            }
-            else {
-                this.runOnUiThread {
-                    Toast.makeText(this, "Invalid URL: ${url()}", Toast.LENGTH_LONG).show()
-                }
+        val validator = NightScoutDomainValidator(this, url(), nightscoutApiSecret)
+        validator.onValidationSuccess {
+            Log.d(TAG, "domain validated: " + it)
+
+            persistUrlAndSecret()
+            setResult(Activity.RESULT_OK)
+            finish()
+        }
+        validator.onValidationError {
+            // TODO: conditional messages based on Exception type
+            Log.d(TAG, "domain validationError " + it.javaClass + " " + it.message)
+
+            this.runOnUiThread {
+                Toast.makeText(this, "Invalid URL: ${url()}", Toast.LENGTH_LONG).show()
             }
         }
+        validator.run()
     }
-
-    private fun testUrl() = url() + "/api/v1/status.json"
-
-    // TODO: this following duplicates much of what we're doing in BloodGlucoseService
-    //       extract a shared class or some utility there
 
     private val nightscoutApiSecret get() = "" + apiSecretEditText.text
-    private fun nsSha1HashedSecret() = Hashing.sha1().hashString(nightscoutApiSecret,Charsets.UTF_8).toString()
-
-    // TODO: ideally we'd differentiate the toast if we detect unauthorized headers...
-    // It's okay if this is blocking because it's run within a separate thread
-    private fun urlValid() : Boolean {
-        val queue = Volley.newRequestQueue(this)
-        val requestFuture : RequestFuture<String> = RequestFuture.newFuture()
-
-        Log.d(TAG, "testing " + testUrl())
-        val stringRequest = object: StringRequest(Method.GET, testUrl(), requestFuture, requestFuture)
-        {
-            @Throws(AuthFailureError::class)
-            override fun getHeaders(): Map<String, String> {
-                val headers = HashMap<String, String>()
-
-                if (nightscoutApiSecret != "") {
-                    Log.d(TAG, "adding API-SECRET header")
-                    headers.put("API-SECRET", nsSha1HashedSecret())
-                }
-                return headers
-            }
-        }
-
-        queue.add(stringRequest)
-
-        try {
-            val response = requestFuture.get(10, TimeUnit.SECONDS)
-            Log.d(TAG, "response: " + response)
-            return response.contains("nightscout")
-        }
-        catch (e: TimeoutException) {
-            // Unclear when we'd actually see this if at all, volley's TimeoutError gets wrapped in
-            // ExecutionException below
-            Log.d(TAG, "TimeoutException")
-            return false
-        }
-        catch(e: ExecutionException) {
-            // This wraps exceptions within the future
-            // eg ExecutionException: com.android.volley.NoConnectionError: java.net.UnknownHostException: Unable to resolve host "foo.bar.baz": No address associated with hostnam
-            // TODO: do something better on timeout, ie potentially still valid, third state
-            Log.d(TAG, "ExecutionException: " + e.message)
-            // invalid secret, valid domain, gives com.android.volley.AuthFailureError
-            // unresolvable domain gives com.android.volley.NoConnectionError
-            // resolvable domain, no response, com.android.volley.TimeoutError
-            // 404 (eg not a NightScout app), com.android.volley.ClientError
-            Log.d(TAG, "cause: " + e.cause.toString())
-            return false
-        }
-        catch(e: InterruptedException) {
-            Log.d(TAG, "InterruptedException: " + e.message)
-            return false
-        }
-        catch(e: Exception) {
-            Log.d(TAG, "Unexpected Exception: " + e.javaClass)
-            return false
-        }
-    }
 }

--- a/app/src/main/java/im/rah/nightwear/ConfigurationActivity.kt
+++ b/app/src/main/java/im/rah/nightwear/ConfigurationActivity.kt
@@ -18,7 +18,7 @@ class ConfigurationActivity : WearableActivity() {
 
     companion object {
         const val TAG:String = "ConfigurationActivity"
-        private val COMMON_TLDS = arrayOf("herokuapp.com", "azurewebsites.net")
+        private val COMMON_TLDS = arrayOf("herokuapp.com", "azurewebsites.net", "fly.dev", "up.railway.app")
         private const val DEFAULT_URL = "https://domain.herokuapp.com"
     }
 

--- a/app/src/main/java/im/rah/nightwear/NightScoutDomainValidator.kt
+++ b/app/src/main/java/im/rah/nightwear/NightScoutDomainValidator.kt
@@ -1,0 +1,72 @@
+package im.rah.nightwear
+
+import android.content.Context
+import android.util.Log
+import com.android.volley.AuthFailureError
+import com.android.volley.DefaultRetryPolicy
+import com.android.volley.toolbox.StringRequest
+import com.android.volley.toolbox.Volley
+import com.google.common.hash.Hashing
+import java.util.HashMap
+
+class NightScoutDomainValidator(val context: Context, val url: String, val secret: String) {
+    private lateinit var validationSucessCallback: (String) -> Unit
+    private lateinit var validationErrorCallback: (java.lang.Exception) -> Unit
+
+    companion object {
+        const val TAG: String = "NightScoutUrlValidator"
+        const val STATUS_PATH: String = "/api/v1/status.json"
+    }
+
+    fun onValidationSuccess(callback: (String) -> Unit) {
+        validationSucessCallback = callback
+    }
+
+    //FIXME: either add error to signature, or probably better split out to multiple callbacks
+    //       eg onAuthenticationError, etc
+    fun onValidationError(callback: (java.lang.Exception) -> Unit) {
+        validationErrorCallback = callback
+    }
+
+    fun run() {
+        val queue = Volley.newRequestQueue(context)
+        val testUrl = url + STATUS_PATH
+        Log.d(TAG, "testing " + testUrl)
+        val stringRequest = object: StringRequest(
+            Method.GET, testUrl,
+            { if (it.contains("nightscout")) validationSucessCallback.invoke(url) },
+            // 401 -> class com.android.volley.AuthFailureError null
+            // - wrong API key
+            // - API key provided when no API key set
+            // 404 -> class com.android.volley.ClientError null
+            // - wrong domain, but resolves
+            //
+            // class com.android.volley.NoConnectionError java.net.UnknownHostException: Unable to resolve host "acme.com": No address associated with hostname
+            // - unresolvable domain
+            // - (after some internal volley timeout) no network connection
+
+            { validationErrorCallback.invoke(it) }
+        )
+        {
+            //@Throws(AuthFailureError::class)
+            override fun getHeaders(): Map<String, String> {
+                val headers = HashMap<String, String>()
+                if (secret != "") {
+                    Log.d(TAG, "adding API-SECRET header")
+                    headers.put("API-SECRET", nsSha1HashedSecret())
+                }
+                return headers
+            }
+        }
+        // we want failure to occur as soon and as clearly as possible so we can infer what the
+        // problem is
+        stringRequest.setShouldCache(false)
+        stringRequest.setShouldRetryConnectionErrors(false)
+        stringRequest.setShouldRetryServerErrors(false)
+        stringRequest.retryPolicy =
+            DefaultRetryPolicy(0, 0,  DefaultRetryPolicy.DEFAULT_BACKOFF_MULT)
+        queue.add(stringRequest)
+    }
+
+    private fun nsSha1HashedSecret() = Hashing.sha1().hashString(secret,Charsets.UTF_8).toString()
+}

--- a/app/src/main/java/im/rah/nightwear/NightScoutDomainValidator.kt
+++ b/app/src/main/java/im/rah/nightwear/NightScoutDomainValidator.kt
@@ -54,7 +54,6 @@ class NightScoutDomainValidator(val context: Context, val url: String, val secre
             }
         )
         {
-            //@Throws(AuthFailureError::class)
             override fun getHeaders(): Map<String, String> {
                 val headers = HashMap<String, String>()
                 if (secret != "") {

--- a/app/src/main/res/layout/activity_configuration.xml
+++ b/app/src/main/res/layout/activity_configuration.xml
@@ -106,6 +106,7 @@
                     android:inputType="textPersonName"
                     android:textSize="12sp" />
 
+
                 <Button
                         android:text="Confirm"
                         android:layout_width="match_parent"
@@ -114,6 +115,13 @@
                         android:textAppearance="@android:style/TextAppearance.Material.Widget.Button"
                         android:textSize="10sp"
                         style="@android:style/Widget.Material.Button.Small" />
+
+                <ProgressBar
+                    android:id="@+id/progress"
+                    style="@android:style/Widget.DeviceDefault.ProgressBar.Small"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:visibility="invisible" />
             </LinearLayout>
         </FrameLayout>
     </ScrollView>

--- a/app/src/main/res/layout/activity_configuration.xml
+++ b/app/src/main/res/layout/activity_configuration.xml
@@ -71,6 +71,7 @@
                         android:layout_height="wrap_content" android:id="@+id/url_label"
                         android:text="Nightscout domain"
                         android:textSize="12sp" android:textAlignment="center"/>
+
                 <TextView
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content" android:id="@+id/url" android:text="https://"
@@ -82,10 +83,28 @@
                         android:text="domain"
                         android:ems="10"
                         android:id="@+id/domain" android:textSize="12sp" android:hint="domain"/>
+
                 <Spinner
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content" android:id="@+id/tld" android:spinnerMode="dialog"
                 />
+
+                <TextView
+                    android:id="@+id/api_secret_label"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="API Secret (optional)"
+                    android:textAlignment="center"
+                    android:textSize="12sp" />
+
+                <EditText
+                    android:id="@+id/api_secret"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:ems="10"
+                    android:hint="API Secret"
+                    android:inputType="textPersonName"
+                    android:textSize="12sp" />
 
                 <Button
                         android:text="Confirm"


### PR DESCRIPTION
Fixes #28
Fixes #38

This adds support for providing a NightScout secret as a token provided with API requests.

It also improves our domain validation handling.

![image](https://user-images.githubusercontent.com/14014/204673134-9ca8576b-5da7-44c9-83c9-ce6fb795475d.png)
